### PR TITLE
feat: add CI for testing builds; fix/l10n: rollback wording

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: Build
+
+on:
+  push:
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/vanilla-os/pico:main
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install build dependencies
+      run: |
+          apt-get update
+          apt-get install -y build-essential gettext meson
+
+    - name: Setup and Build
+      run: meson setup build

--- a/abroot-rollback-notifier.in
+++ b/abroot-rollback-notifier.in
@@ -91,7 +91,7 @@ class ABRollbackCheck:
 
         title = _("Rollback is possible")
         description = _(
-            "It appears you booted to the previous root. Do you want to rollback to the current state?"
+            "It appears you booted to the previous root. Do you want to rollback to this state?"
         )
         dialog_type = "question"
         adw_res = self.adw_dialog.show_dialog(title, description, dialog_type)

--- a/meson.build
+++ b/meson.build
@@ -19,7 +19,6 @@ conf.set('pkgdatadir', pkgdatadir)
 configure_file(
   input: 'abroot-rollback-notifier.in',
   output: 'abroot-rollback-notifier',
-  install_mode: 'rwxr-xr-x',
   configuration: conf,
   install: true,
   install_dir: get_option('bindir'),

--- a/po/abroot-rollback-notifier.pot
+++ b/po/abroot-rollback-notifier.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: abroot-rollback-notifier\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-13 20:17+0530\n"
+"POT-Creation-Date: 2024-05-30 14:54+0530\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -23,8 +23,8 @@ msgstr ""
 
 #: abroot-rollback-notifier.in:94
 msgid ""
-"It appears you booted to the previous root. Do you want to rollback to the "
-"current state?"
+"It appears you booted to the previous root. Do you want to rollback to this "
+"state?"
 msgstr ""
 
 #: abroot-rollback-notifier.in:102


### PR DESCRIPTION
## Changes

- Added a small CI to build the project (useful for validating that translations don't break the meson build).
- Fixed duplicate `install_mode` in the `meson.build` file's configure_file parameter. (This resolves a warning shown during meson's setup). [^2]
- Reworded the rollback description (after seeing the suggestions on Discord); feel free to suggest something else if you think it would be better.

## Reference

[^2]:

```meson
➜  abroot-rollback-notifier git:(fix/l10n) ✗ meson setup build
The Meson build system
Version: 1.4.0
Source dir: /home/kbdharunkrishna/Downloads/abroot-rollback-notifier
Build dir: /home/kbdharunkrishna/Downloads/abroot-rollback-notifier/build
Build type: native build
meson.build:20: WARNING: Keyword argument "install_mode" defined multiple times.
WARNING: This will be an error in future Meson releases.
Project name: abroot-rollback-notifier
Project version: 0.0.1
Host machine cpu family: x86_64
Host machine cpu: x86_64
Program python3 found: YES (/usr/bin/python3)
Configuring abroot-rollback-notifier using configuration
Program msgfmt found: YES (/usr/bin/msgfmt)
Program msginit found: YES (/usr/bin/msginit)
Program msgmerge found: YES (/usr/bin/msgmerge)
Program xgettext found: YES (/usr/bin/xgettext)
Build targets in project: 8

Found ninja-1.11.1 at /usr/bin/ninja
➜  abroot-rollback-notifier git:(fix/l10n) ✗ meson setup build --reconfigure
The Meson build system
Version: 1.4.0
Source dir: /home/kbdharunkrishna/Downloads/abroot-rollback-notifier
Build dir: /home/kbdharunkrishna/Downloads/abroot-rollback-notifier/build
Build type: native build
Project name: abroot-rollback-notifier
Project version: 0.0.1
Host machine cpu family: x86_64
Host machine cpu: x86_64
Program python3 found: YES (/usr/bin/python3)
Configuring abroot-rollback-notifier using configuration
Program msgfmt found: YES (/usr/bin/msgfmt)
Program msginit found: YES (/usr/bin/msginit)
Program msgmerge found: YES (/usr/bin/msgmerge)
Program xgettext found: YES (/usr/bin/xgettext)
Build targets in project: 8

Found ninja-1.11.1 at /usr/bin/ninja
```